### PR TITLE
Don't trigger `ReactorInnerPublisherIgnored` for likely non-Publisher types

### DIFF
--- a/reactor-error-prone/src/main/java/com/github/lhotari/reactor/errorprone/ReactorInnerPublisherIgnored.java
+++ b/reactor-error-prone/src/main/java/com/github/lhotari/reactor/errorprone/ReactorInnerPublisherIgnored.java
@@ -8,6 +8,7 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
@@ -50,6 +51,7 @@ public class ReactorInnerPublisherIgnored extends BugChecker implements MethodIn
             return NO_MATCH;
         }
 
+        Type objectType = Suppliers.typeFromString("java.lang.Object").get(state);
         Type fluxType = Suppliers.typeFromString("reactor.core.publisher.Flux").get(state);
         Type monoType = Suppliers.typeFromString("reactor.core.publisher.Mono").get(state);
         Type receiverType = ASTHelpers.getReceiverType(tree);
@@ -61,7 +63,9 @@ public class ReactorInnerPublisherIgnored extends BugChecker implements MethodIn
                 0,
                 state.getTypes());
 
-        if (typeArg == null || !(ASTHelpers.isSubtype(fluxType, typeArg, state) || ASTHelpers.isSubtype(monoType, typeArg, state))) {
+        if (typeArg == null
+                || ASTHelpers.isSubtype(objectType, typeArg, state)
+                || !(ASTHelpers.isSubtype(fluxType, typeArg, state) || ASTHelpers.isSubtype(monoType, typeArg, state))) {
             return NO_MATCH;
         }
 

--- a/reactor-error-prone/src/test/resources/com/github/lhotari/reactor/errorprone/testdata/ReactorInnerPublisherIgnoredNegativeCases.java
+++ b/reactor-error-prone/src/test/resources/com/github/lhotari/reactor/errorprone/testdata/ReactorInnerPublisherIgnoredNegativeCases.java
@@ -13,6 +13,14 @@ public class ReactorInnerPublisherIgnoredNegativeCases {
         return null;
     }
 
+    private static <T> Flux<T> getFluxAnyType() {
+        return null;
+    }
+
+    private static <T> Mono<T> getMonoAnyType() {
+        return null;
+    }
+
     private static Flux getFluxRaw() {
         return null;
     }
@@ -41,6 +49,28 @@ public class ReactorInnerPublisherIgnoredNegativeCases {
         Arrays.asList(1, 2, 3).forEach(n -> getMono().thenEmpty(null).subscribe());
         Arrays.asList(1, 2, 3).forEach(n -> getMono().thenReturn(null).subscribe());
         Arrays.asList(1, 2, 3).forEach(n -> getMono().and(null).subscribe());
+    }
+
+    {
+        getFluxAnyType().then().subscribe();
+        getFluxAnyType().thenMany(null).subscribe();
+        getFluxAnyType().thenEmpty(null).subscribe();
+        getFluxAnyType().and(null).subscribe();
+        getMonoAnyType().then().subscribe();
+        getMonoAnyType().thenMany(null).subscribe();
+        getMonoAnyType().thenEmpty(null).subscribe();
+        getMonoAnyType().thenReturn(null).subscribe();
+        getMonoAnyType().and(null).subscribe();
+
+        Arrays.asList(1, 2, 3).forEach(n -> getFluxAnyType().then().subscribe());
+        Arrays.asList(1, 2, 3).forEach(n -> getFluxAnyType().thenMany(null).subscribe());
+        Arrays.asList(1, 2, 3).forEach(n -> getFluxAnyType().thenEmpty(null).subscribe());
+        Arrays.asList(1, 2, 3).forEach(n -> getFluxAnyType().and(null).subscribe());
+        Arrays.asList(1, 2, 3).forEach(n -> getMonoAnyType().then().subscribe());
+        Arrays.asList(1, 2, 3).forEach(n -> getMonoAnyType().thenMany(null).subscribe());
+        Arrays.asList(1, 2, 3).forEach(n -> getMonoAnyType().thenEmpty(null).subscribe());
+        Arrays.asList(1, 2, 3).forEach(n -> getMonoAnyType().thenReturn(null).subscribe());
+        Arrays.asList(1, 2, 3).forEach(n -> getMonoAnyType().and(null).subscribe());
     }
 
     // raw types
@@ -77,6 +107,18 @@ public class ReactorInnerPublisherIgnoredNegativeCases {
             getMono().thenEmpty(null).subscribe();
             getMono().thenReturn(null).subscribe();
             getMono().and(null).subscribe();
+        }
+
+        if (false) {
+            getFluxAnyType().then().subscribe();
+            getFluxAnyType().thenMany(null).subscribe();
+            getFluxAnyType().thenEmpty(null).subscribe();
+            getFluxAnyType().and(null).subscribe();
+            getMonoAnyType().then().subscribe();
+            getMonoAnyType().thenMany(null).subscribe();
+            getMonoAnyType().thenEmpty(null).subscribe();
+            getMonoAnyType().thenReturn(null).subscribe();
+            getMonoAnyType().and(null).subscribe();
         }
 
         // raw types


### PR DESCRIPTION
In most cases the values emitted by an arbitrary `Mono<T>` or `Flux<T>` are not themselves `Publisher`s. By skipping such cases likely false-positives are avoided. This mirrors the existing treatment of raw types.